### PR TITLE
Add fixes related to optinal fields and those without validation function

### DIFF
--- a/assets/javascripts/admin/lib/validations.js.es6
+++ b/assets/javascripts/admin/lib/validations.js.es6
@@ -32,8 +32,12 @@ export const validateUserFieldsFormat = userFields => {
     */
     isValidData = userFields.every(userField => {
       const { field, value } = userField;
-      const validationFn = fieldTypesValidations[field.field_type];
-      return validationFn && validationFn(value);
+      // If there is no validation func for a custom userField we assume identity function
+      const validationFn =
+        fieldTypesValidations[field.field_type] || (() => true);
+
+      // If the field has a value we will check its format otherwise required empty fields will prevent submit by default
+      return value ? validationFn && validationFn(value) : true;
     });
   }
 

--- a/assets/javascripts/admin/pre-initializers/custom-field-types.js.es6
+++ b/assets/javascripts/admin/pre-initializers/custom-field-types.js.es6
@@ -35,17 +35,20 @@ const initializeCustomFieldTypes = api => {
 
     @on("init")
     bindFixedOptions() {
-      let options;
+      // Prevent to break built-in dropdowns by checking already defined options
+      let options = this.field.options;
 
-      switch (this.field.field_type) {
-        case types.state:
-          options = usaStates;
-          break;
-        default:
-          break;
+      if (!options) {
+        switch (this.field.field_type) {
+          case types.state:
+            options = usaStates;
+            break;
+          default:
+            break;
+        }
       }
 
-      this.field.options = options;
+      Ember.set(this.field, "options", options);
     },
 
     @observes("value")

--- a/assets/javascripts/admin/pre-initializers/custom-field-types.js.es6
+++ b/assets/javascripts/admin/pre-initializers/custom-field-types.js.es6
@@ -23,14 +23,14 @@ const initializeCustomFieldTypes = api => {
   });
 
   api.modifyClass("component:user-field", {
-    classNameBindings: ["isValidFormat::error", "hasFormat:has-format"],
+    classNameBindings: ["isValidFormat::error"],
     isValidFormat: true,
-    hasFormat: false,
 
     @on("init")
     enhanceFieldComponentValidation() {
-      this._enhancedValidationFn = fieldTypesValidations[this.field.field_type];
-      this.set("hasFormat", this._enhancedValidationFn !== undefined);
+      // If there is no validation func for a custom userField we assume identity function
+      this._enhancedValidationFn =
+        fieldTypesValidations[this.field.field_type] || (() => true);
     },
 
     @on("init")
@@ -54,7 +54,14 @@ const initializeCustomFieldTypes = api => {
         Ember.run.debounce(
           this,
           value => {
-            this.set("isValidFormat", this._enhancedValidationFn(value));
+            let isValid = true;
+
+            // If there is no value at all we will keep the UI idle
+            if (value) {
+              isValid = this._enhancedValidationFn(value);
+            }
+
+            this.set("isValidFormat", isValid);
           },
           this.get("value"),
           250


### PR DESCRIPTION
Closes https://github.com/debtcollective/parent/issues/268

_Fixes:_
- Use Ember.set to set custom options preventing fatal error on edge cases, Avoid to break built-in dropdowns
- Prevent to run validations for empty value fields, set default validation function to return true

![http://recordit.co/7qj6dMaYYn](http://recordit.co/7qj6dMaYYn.gif)